### PR TITLE
Hook editor-extract plugin to sass ruleset

### DIFF
--- a/bud.config.js
+++ b/bud.config.js
@@ -25,7 +25,7 @@ export default async (app) => {
     },
   })
 
-  app.build.rules.css.setUse(items => ['precss', 'css', 'wp-editor', 'postcss'])
+  app.build.rules.sass.setUse(items => ['minicss', 'css', 'wp-editor', 'postcss', 'resolveUrl', 'sass'])
 
 
   /**


### PR DESCRIPTION
This should allow editor extraction to work with SASS.